### PR TITLE
Adds cloning, merging, element shortcuts

### DIFF
--- a/elements.js
+++ b/elements.js
@@ -1,54 +1,193 @@
 class JSONElement {
   constructor(element) {
+    if (ElementsJS.isJSONElement(element)) {
+      return ElementsJS.create(ElementsJS.getJSONtemplate(element));
+    } else if (typeof element === "object") {
+      return ElementsJS.create(element);
+    } else {
+      throw new Error("JSONElement requires either an object that follows the JSONElement schema or an element created with ElementsJS.")
+    }
+  }
+
+  static a(template=undefined, src=undefined, innerHTML=undefined, target=undefined) {
+    const defaultTemplate = {"type": "a"};
+
+    if (src) {
+      defaultTemplate.attributes.src = src;
+    }
+
+    if (innerHTML) {
+      defaultTemplate.innerHTML = innerHTML;
+    }
+
+    if (target) {
+      defaultTemplate.attributes.target = target;
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
     return ElementsJS.create(element);
   }
 
-  static a(innerHTML, src, target, template=undefined) {
-
-  }
-
   static div(template=undefined) {
+    const defaultTemplate = {"type": "div"};
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
+  }
+
+  static h1(template=undefined, innerHTML=undefined) {
+    const defaultTemplate = {"type": "h1"};
+
+    if (innerHTML) {
+      defaultTemplate.innerHTML = innerHTML;
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
+  }
+
+  static h2(template=undefined, innerHTML=undefined) {
+    const defaultTemplate = {"type": "h2"};
     
+    if (innerHTML) {
+      defaultTemplate.innerHTML = innerHTML;
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
   }
 
-  static h1(innerHTML, template=undefined) {
-
-  }
-
-  static h2(innerHTML, template=undefined) {
-
-  }
-
-  static h3(innerHTML, template=undefined) {
-
-  }
-
-  static h4(innerHTML, template=undefined) {
-
-  }
-
-  static h5(innerHTML, template=undefined) {
-
-  }
-
-  static h6(innerHTML, template=undefined) {
-
-  }
-
-  static img(altText, src, template=undefined) {
+  static h3(template=undefined, innerHTML=undefined) {
+    const defaultTemplate = {"type": "h3"};
     
+    if (innerHTML) {
+      defaultTemplate.innerHTML = innerHTML;
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
   }
 
-  static ol(items, template=undefined) {
+  static h4(template=undefined, innerHTML=undefined) {
+    const defaultTemplate = {"type": "h4"};
+    
+    if (innerHTML) {
+      defaultTemplate.innerHTML = innerHTML;
+    }
 
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
   }
 
-  static p(innerHTML, template=undefined) {
+  static h5(template=undefined, innerHTML=undefined) {
+    const defaultTemplate = {"type": "h5"};
+    
+    if (innerHTML) {
+      defaultTemplate.innerHTML = innerHTML;
+    }
 
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
+  }
+
+  static h6(template=undefined, innerHTML=undefined) {
+    const defaultTemplate = {"type": "h6"};
+    
+    if (innerHTML) {
+      defaultTemplate.innerHTML = innerHTML;
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
+  }
+
+  static img(template=undefined, src=undefined, alt=undefined) {
+    const defaultTemplate = {"type": "img"};
+    
+    if (src) {
+      defaultTemplate.attributes.src = src;
+    }
+
+    if (alt) {
+      defaultTemplate.attributes.alt = alt;
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
+  }
+
+  static ol(template=undefined, items=undefined) {
+    const defaultTemplate = {"type": "ol"};
+    
+    if (items) {
+      defaultTemplate.childArray = [];
+
+      for (const item in items) {
+        const thisItem = {
+          "type": "li",
+          "innerHTML": item
+        }
+
+        defaultTemplate.childArray.push(thisItem);
+      }
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
+  }
+
+  static p(template=undefined, innerHTML=undefined) {
+    const defaultTemplate = {"type": "p"};
+    
+    if (innerHTML) {
+      defaultTemplate.innerHTML = innerHTML;
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
+  }
+
+  static pre(template=undefined, innerHTML=undefined) {
+    const defaultTemplate = {"type": "pre"};
+    
+    if (innerHTML) {
+      defaultTemplate.innerHTML = innerHTML;
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
   }
 
   static ul(items, template=undefined) {
+    const defaultTemplate = {"type": "ul"};
+    
+    if (items) {
+      defaultTemplate.childArray = [];
 
+      for (const item in items) {
+        const thisItem = {
+          "type": "li",
+          "innerHTML": item
+        }
+
+        defaultTemplate.childArray.push(thisItem);
+      }
+    }
+
+    const element = ElementsJS.merge(template, defaultTemplate);
+
+    return ElementsJS.create(element);
   }
 }
 
@@ -190,6 +329,20 @@ class ElementsJS {
     return this.#SYMBOL;
   }
 
+  static #mergeTemplates(originalTemplate, modifiedTemplate) {
+    var updatedTemplate = {};
+    
+    if (typeof originalTemplate === "object") {
+      updatedTemplate = structuredClone(originalTemplate);
+    }
+
+    for (const [property, value] of Object.entries(modifiedTemplate)) {
+      updatedTemplate[property] = structuredClone(value);
+    }
+
+    return updatedTemplate;
+  }
+
   constructor() {
     throw new Error("The ElementsJS class cannot be instantiated.");
   }
@@ -206,7 +359,16 @@ class ElementsJS {
     return this.#newElements(elements, nodeMap);
   }
 
+  static merge(template1, template2) {
+    return this.#mergeTemplates(template1, template2);
+  }
+
   static getJSONtemplate(element) {
+    return element[this.key];
+  }
+
+  static updateJSONtemplate(element, template) {
+    element[this.key] = this.#mergeTemplates(this.getJSONtemplate(element), template);
     return element[this.key];
   }
 

--- a/elements.js
+++ b/elements.js
@@ -5,23 +5,29 @@ class JSONElement {
     } else if (typeof element === "object") {
       return ElementsJS.create(element);
     } else {
-      throw new Error("JSONElement requires either an object that follows the JSONElement schema or an element created with ElementsJS.")
+      throw new Error("JSONElement requires either an object that follows the JSONElement schema or an element created with the elements.js library.")
     }
   }
 
   static a(template=undefined, src=undefined, innerHTML=undefined, target=undefined) {
     const defaultTemplate = {"type": "a"};
 
-    if (src) {
-      defaultTemplate.attributes.src = src;
+    if (innerHTML) {
+      defaultTemplate["innerHTML"] = innerHTML;
     }
 
-    if (innerHTML) {
-      defaultTemplate.innerHTML = innerHTML;
+    const attributes = {};
+
+    if (src) {
+      attributes["src"] = encodeURI(src);
     }
 
     if (target) {
-      defaultTemplate.attributes.target = target;
+      attributes["target"] = target;
+    }
+
+    if (Object.keys(attributes).length) {
+      defaultTemplate["attributes"] = ElementsJS.merge(template.attributes, attributes);
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -31,6 +37,7 @@ class JSONElement {
 
   static div(template=undefined) {
     const defaultTemplate = {"type": "div"};
+
     const element = ElementsJS.merge(template, defaultTemplate);
 
     return ElementsJS.create(element);
@@ -40,7 +47,7 @@ class JSONElement {
     const defaultTemplate = {"type": "h1"};
 
     if (innerHTML) {
-      defaultTemplate.innerHTML = innerHTML;
+      defaultTemplate["innerHTML"] = innerHTML;
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -52,7 +59,7 @@ class JSONElement {
     const defaultTemplate = {"type": "h2"};
     
     if (innerHTML) {
-      defaultTemplate.innerHTML = innerHTML;
+      defaultTemplate["innerHTML"] = innerHTML;
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -64,7 +71,7 @@ class JSONElement {
     const defaultTemplate = {"type": "h3"};
     
     if (innerHTML) {
-      defaultTemplate.innerHTML = innerHTML;
+      defaultTemplate["innerHTML"] = innerHTML;
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -76,7 +83,7 @@ class JSONElement {
     const defaultTemplate = {"type": "h4"};
     
     if (innerHTML) {
-      defaultTemplate.innerHTML = innerHTML;
+      defaultTemplate["innerHTML"] = innerHTML;
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -88,7 +95,7 @@ class JSONElement {
     const defaultTemplate = {"type": "h5"};
     
     if (innerHTML) {
-      defaultTemplate.innerHTML = innerHTML;
+      defaultTemplate["innerHTML"] = innerHTML;
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -100,7 +107,7 @@ class JSONElement {
     const defaultTemplate = {"type": "h6"};
     
     if (innerHTML) {
-      defaultTemplate.innerHTML = innerHTML;
+      defaultTemplate["innerHTML"] = innerHTML;
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -111,12 +118,18 @@ class JSONElement {
   static img(template=undefined, src=undefined, alt=undefined) {
     const defaultTemplate = {"type": "img"};
     
+    const attributes = {};
+
     if (src) {
-      defaultTemplate.attributes.src = src;
+      attributes["src"] = encodeURI(src);
     }
 
     if (alt) {
-      defaultTemplate.attributes.alt = alt;
+      attributes["alt"] = alt;
+    }
+
+    if (Object.keys(attributes).length) {
+      defaultTemplate["attributes"] = ElementsJS.merge(template["attributes"], attributes);
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -128,7 +141,7 @@ class JSONElement {
     const defaultTemplate = {"type": "ol"};
     
     if (items) {
-      defaultTemplate.childArray = [];
+      defaultTemplate["childArray"] = [];
 
       for (const item in items) {
         const thisItem = {
@@ -136,7 +149,7 @@ class JSONElement {
           "innerHTML": item
         }
 
-        defaultTemplate.childArray.push(thisItem);
+        defaultTemplate["childArray"].push(thisItem);
       }
     }
 
@@ -149,7 +162,7 @@ class JSONElement {
     const defaultTemplate = {"type": "p"};
     
     if (innerHTML) {
-      defaultTemplate.innerHTML = innerHTML;
+      defaultTemplate["innerHTML"] = innerHTML;
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -161,7 +174,7 @@ class JSONElement {
     const defaultTemplate = {"type": "pre"};
     
     if (innerHTML) {
-      defaultTemplate.innerHTML = innerHTML;
+      defaultTemplate["innerHTML"] = innerHTML;
     }
 
     const element = ElementsJS.merge(template, defaultTemplate);
@@ -173,7 +186,7 @@ class JSONElement {
     const defaultTemplate = {"type": "ul"};
     
     if (items) {
-      defaultTemplate.childArray = [];
+      defaultTemplate["childArray"] = [];
 
       for (const item in items) {
         const thisItem = {
@@ -181,7 +194,7 @@ class JSONElement {
           "innerHTML": item
         }
 
-        defaultTemplate.childArray.push(thisItem);
+        defaultTemplate["childArray"].push(thisItem);
       }
     }
 

--- a/elements.js
+++ b/elements.js
@@ -2,6 +2,54 @@ class JSONElement {
   constructor(element) {
     return ElementsJS.create(element);
   }
+
+  static a(innerHTML, src, target, template=undefined) {
+
+  }
+
+  static div(template=undefined) {
+    
+  }
+
+  static h1(innerHTML, template=undefined) {
+
+  }
+
+  static h2(innerHTML, template=undefined) {
+
+  }
+
+  static h3(innerHTML, template=undefined) {
+
+  }
+
+  static h4(innerHTML, template=undefined) {
+
+  }
+
+  static h5(innerHTML, template=undefined) {
+
+  }
+
+  static h6(innerHTML, template=undefined) {
+
+  }
+
+  static img(altText, src, template=undefined) {
+    
+  }
+
+  static ol(items, template=undefined) {
+
+  }
+
+  static p(innerHTML, template=undefined) {
+
+  }
+
+  static ul(items, template=undefined) {
+
+  }
 }
 
 class ElementsJS {


### PR DESCRIPTION
This PR adds the following features to the elements.js library:

- The ability to clone elements created with the elements.js library (`new JSONElement(<existing element>)`).
- A way to merge templates (`ElementsJS.merge(<template 1>, <template 2>)`).
- A set of static element shortcuts that can be used to quickly generate commonly used HTML elements:
  - `a`
  - `div`
  - `h1` to `h6`
  - `img`
  - `ol` and `ul`
  - `p`
  - `pre`